### PR TITLE
Add delete question options and refactor payment handler

### DIFF
--- a/src/Concerns/HandlesConversations.php
+++ b/src/Concerns/HandlesConversations.php
@@ -115,7 +115,11 @@ trait HandlesConversations
 
         $variations[self::CLEANUP_CLOSURE_NAME] = function () use ($messageId) {
             /** @var Conversation $this */
-            if (isset($this->chat)) {
+            if (isset($this->chat) && $this->chat->step->deleteQuestion) {
+                $this->chat->deleteMessage($messageId)->send();
+            }
+
+            if (isset($this->chat) && $this->chat->step->deleteQuestionButtons) {
                 $this->chat->deleteKeyboard($messageId)->send();
             }
         };

--- a/src/DTO/Conversations/Step.php
+++ b/src/DTO/Conversations/Step.php
@@ -18,6 +18,9 @@ final class Step implements Arrayable
     /** @var array|Closure[] */
     public array $variations = [];
 
+    public bool $deleteQuestion = true;
+    public bool $deleteQuestionButtons = false;
+
     public function setChat(TelegraphChat $chat): void
     {
         assert($this->conversation !== null);

--- a/src/Handlers/WebhookHandler.php
+++ b/src/Handlers/WebhookHandler.php
@@ -224,7 +224,7 @@ abstract class WebhookHandler
         // .. do nothing
     }
 
-    protected function handleSuccessfulPayment(SuccessfulPayment $payment): void
+    protected function handleSuccessfulPayment(SuccessfulPayment $data): void
     {
         //
     }


### PR DESCRIPTION
Added new boolean properties 'deleteQuestion' and 'deleteQuestionButtons' to conversation steps  to provide more control over the conversation flow.

Refactored handleSuccessfulPayment method by renaming '$payment' parameter to '$data' for better readability. Modified cleanup closure in handleConversations to consider new properties. Now we can decide to delete a question or its buttons separately after a step.

These changes